### PR TITLE
deps.sh: fix sasquatch install

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -84,7 +84,10 @@ function install_yaffshiv
 function install_sasquatch
 {
     git clone --quiet --depth 1 --branch "master" https://github.com/devttys0/sasquatch
-    (cd sasquatch && $SUDO ./build.sh)
+    (cd sasquatch &&
+        wget https://github.com/devttys0/sasquatch/pull/47.patch &&
+        patch -p1 < 47.patch &&
+        $SUDO ./build.sh)
     $SUDO rm -rf sasquatch
 }
 


### PR DESCRIPTION
Apply https://github.com/devttys0/sasquatch/pull/47 to fix build failure
with latest gcc

It should be noted that sasquatch has not been updated since March 2021

Fix #498

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>